### PR TITLE
diffuse from heatsource, not LED 3

### DIFF
--- a/src/led_effect.py
+++ b/src/led_effect.py
@@ -890,7 +890,7 @@ class ledEffect:
                 c = randint(0,self.effectCutoff)
                 self.heatMap[h] -= (self.heatMap[h] - c >= 0 ) * c
 
-            for i in range(self.ledCount - 1, 2, -1):
+            for i in range(self.ledCount - 1, self.heatSource, -1):
                 d = (self.heatMap[i - 1] +
                      self.heatMap[i - 2] +
                      self.heatMap[i - 3] ) / 3
@@ -954,7 +954,7 @@ class ledEffect:
                     c = randint(0, cooling)
                     self.heatMap[h] -= (self.heatMap[h] - c >= 0 ) * c
 
-                for i in range(self.ledCount - 1, 2, -1):
+                for i in range(self.ledCount - 1, self.heatSource, -1):
                     d = (self.heatMap[i - 1] +
                          self.heatMap[i - 2] +
                          self.heatMap[i - 3] ) / 3

--- a/src/led_effect.py
+++ b/src/led_effect.py
@@ -346,9 +346,13 @@ class ledEffect:
                     if led:
                         if '-' in led:
                             start, stop = map(int,led.split('-'))
-                            for i in range(start-1, stop):
-                                self.leds.append([ledChain, 
-                                    int(i) * color_len, getColorData, color_len, offset])
+                            ledList = list(range(start-1, stop))
+                            if not ledList:
+                                ledList = list(reversed(range(stop-1, start)))
+                            if ledList:
+                                for i in ledList:
+                                    self.leds.append([ledChain,
+                                        int(i) * color_len, getColorData, color_len, offset])
                         else:
                             for i in led.split(','):
                                 self.leds.append([ledChain,


### PR DESCRIPTION
There's a bug in the "Fire" implementation which causes the heat diffusion to skip the first 3 LEDs. This leaves the third, and possibly second LEDs unlit if the string is too short. Instead, we should start the diffusion from above the calculated heat source length.