### PR TITLE
Fixes progress effect to turn off all LEDs when progress==0

### DIFF
--- a/src/led_effect.py
+++ b/src/led_effect.py
@@ -156,10 +156,8 @@ class ledFrameHandler:
     def _pollProgress(self, eventtime):
         status = self.displayStatus.get_status(eventtime)
         p = status.get('progress')
-        if p:
+        if p is not None:
             self.printProgress = int(p * 100)
-        else:
-            self.printProgress = 0
         return eventtime + 1
 
     # Todo: Make color temperature configurable in Neopixel config and 

--- a/src/led_effect.py
+++ b/src/led_effect.py
@@ -158,6 +158,8 @@ class ledFrameHandler:
         p = status.get('progress')
         if p:
             self.printProgress = int(p * 100)
+        else:
+            self.printProgress = 0
         return eventtime + 1
 
     # Todo: Make color temperature configurable in Neopixel config and 
@@ -1043,7 +1045,8 @@ class ledEffect:
                 gradient.shift(1,1)
                 frames.append(gradient[:self.ledCount])
 
-            for i in range(101):
+            self.thisFrame.append(colorArray([0.0,0.0,0.0] * self.ledCount))
+            for i in range(1, 101):
                 x = int((i / 101.0) * self.ledCount)
                 self.thisFrame.append(frames[x])
 


### PR DESCRIPTION
# Previous Behavior
The first LED would always remain on even if progress==0. M74 P0 essentially has no effect.

# Cause
- The polling of the progress state would not change the internal printProgress variable when 0, due to an `if p:` statement evaluating to false
- The first frame in the pre-rendered progress array [0...100] would still have the first LED set

# Fix
- Added an `else` clause to the `if p:` to set the internal variable to 0 if klipper progress state is None or 0
- Implicitly added the first pre-rendered frame to be all LEDs off, frames [1..100] are rendered as normal
   - In my case, I have 10 LEDs. P0 will turn all off, P1 will turn the first one on, P11 will turn the second one on, etc.