### PR TITLE
Added IMMEDIATE param to SET_LED_EFFECT so you don't need to wait for…

### DIFF
--- a/src/led_effect.py
+++ b/src/led_effect.py
@@ -437,14 +437,20 @@ class ledEffect:
         self.fadeTime = fadetime
         self.fadeEndTime = self.handler.reactor.monotonic() + fadetime
 
+    def reset_fadeValue(self):
+        self.fadeValue = 0.0
+        self.nextEventTime = self.handler.reactor.NEVER
+
     def cmd_SET_LED_EFFECT(self, gcmd):
         self.set_fade_time(gcmd.get_float('FADETIME', 0.0))
         if gcmd.get_int('STOP', 0) == 1:
             if self.enabled:
-                self.set_fade_time(gcmd.get_float('FADETIME', 0.0))
+                if gcmd.get_int('IMMEDIATE', 0) == 1:
+                    self.reset_fadeValue()
+                else:
+                    self.set_fade_time(gcmd.get_float('FADETIME', 0.0))
             self.set_enabled(False)
         else:
-            self.set_fade_time(gcmd.get_float('FADETIME', 0.0))
             self.set_enabled(True)
 
     def _handle_shutdown(self):


### PR DESCRIPTION
The use case is switching leds from led-effect control to straight RGB in a single macro.  The IMMEDIATE flag stops the effect immediately. That allows for setting via standard LED control immediately afterwards without waiting form the effect to turn at the next scheduling event.