### PR TITLE
Add RESTART parameter to SET_LED_EFFECT

### DIFF
--- a/docs/LED_Effect.md
+++ b/docs/LED_Effect.md
@@ -135,6 +135,11 @@ out in one second. We can also fade out all effects by running
 using the `REPLACE` parameter with `SET_LED_EFFECT` (see above): 
 `SET_LED_EFFECT EFFECT=panel_idle REPLACE=1 FADETIME=1.0`
 
+#### Restarting Effects
+When an effect is stopped and then started again, it resumes from the frame where 
+it last left off.  To restart the effect from the beginning, specify the `RESTART` 
+parameter: `SET_LED_EFFECT EFFECT=panel_idle RESTART=1`.
+
 ### Additional effect level parameters
 
 autostart: true

--- a/src/led_effect.py
+++ b/src/led_effect.py
@@ -487,6 +487,10 @@ class ledEffect:
             self.nextEventTime = self.handler.reactor.NOW
             self.handler._getFrames(self.handler.reactor.NOW)
     
+    def reset_frame(self):
+        for layer in self.layers:
+            layer.frameNumber = 0
+
     def set_fade_time(self, fadetime):
         self.fadeTime = fadetime
         self.fadeEndTime = self.handler.reactor.monotonic() + fadetime
@@ -511,6 +515,8 @@ class ledEffect:
 
             if not self.enabled:
                 self.set_fade_time(parmFadeTime)
+            if gcmd.get_int('RESTART', 0) >= 1:
+                self.reset_frame()
             self.set_enabled(True)
 
     def _handle_shutdown(self):


### PR DESCRIPTION
Adds a RESTART parameter to the SET_LED_EFFECT command which resets the animation, causing it to start at the beginning.
