### PR TITLE
Add cylon effect

### DIFF
--- a/docs/LED_Effect.md
+++ b/docs/LED_Effect.md
@@ -326,6 +326,13 @@ the "head" of the comet and the remaining colors are blended into the "tail"
     Palette:          Color of "head" and gradient of "tail"
 Identical settings as Comet, but with multiple lights chasing each other.
 
+#### Cylon
+    Effect Rate:  1   How fast the cylon sweeps
+    Cutoff:       0   Not used but must be provided
+    Palette:          Color of sweeping LED
+A light moves between each end of the strip. Multiple colors can be provided;
+the color will change after each sweep.
+
 #### Heater
     Effect Rate:  1   Minimum temperature to activate effect
     Cutoff:       0   Disable effect once temp is reached

--- a/src/led_effect.py
+++ b/src/led_effect.py
@@ -822,6 +822,40 @@ class ledEffect:
 
             self.frameCount = len(self.thisFrame)
 
+    #Cylon, single LED bounces from start to end of strip
+    class layerCylon(_layerBase):
+        def __init__(self,  **kwargs):
+            super(ledEffect.layerCylon, self).__init__(**kwargs)
+
+            self.paletteColors = colorArray(COLORS, self.paletteColors)
+
+            if self.effectRate <= 0:
+                raise Exception("effect rate for cylon must be > 0")
+
+            # How many frames per sweep animation.
+            frames = int(self.effectRate / self.frameRate)
+
+            direction = True
+
+            for _ in range(len(self.paletteColors) % 2 + 1):
+                for c in range(0, len(self.paletteColors)):
+                    color = self.paletteColors[c]
+
+                    for frame in range(frames):
+                        pct = frame / (frames - 1)
+                        newFrame = []
+
+                        p = int(round((self.ledCount - 2) * pct) if direction else 1 + round(((self.ledCount - 2) * (1 - pct))))
+
+                        for i in range(self.ledCount):
+                            newFrame += color if p == i else [0.0] * COLORS
+
+                        self.thisFrame.append(newFrame)
+
+                    direction = not direction
+
+            self.frameCount = len(self.thisFrame)
+
     #Color gradient over all LEDs
     class layerGradient(_layerBase):
         def __init__(self,  **kwargs):


### PR DESCRIPTION
Example config:

    [led_effect bed_idle]
    autostart: true
    frame_rate: 30
    leds:
        neopixel:bed_lights
    layers:
        cylon 0.75 1 top (1,0,0),(0,1,0),(0,0,1)

### Examples

![WhatsAppVideo2024-03-01at20 12 39-ezgif com-video-to-gif-converter](https://github.com/julianschill/klipper-led_effect/assets/235730/33036598-4d4a-4709-b879-86e50b8d76f9)
![WhatsAppVideo2024-03-01at20 14 08-ezgif com-video-to-gif-converter](https://github.com/julianschill/klipper-led_effect/assets/235730/a0b772b4-6739-403c-8398-8456a9bb93e4)
