### PR TITLE
Update README.md - Location of py file for manual install

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Stop Klipper:
 
 Link the file in the Klipper directory (adjust the paths as needed):
 
-    ln -s klipper-led_effect/led_effect.py ~/klipper/klippy/extras/led_effect.py
+    ln -s klipper-led_effect/src/led_effect.py ~/klipper/klippy/extras/led_effect.py
 
 Start Klipper:
 


### PR DESCRIPTION
From some troubleshooting on the klipper discord, noticed that a manual install has the location of the python module in the root and not in the src directory.

Thanks
James