### PR TITLE
Fix heater effect with effect rate set

### DIFF
--- a/src/led_effect.py
+++ b/src/led_effect.py
@@ -927,7 +927,7 @@ class ledEffect:
             if heaterTarget > 0.0 and heaterCurrent > 0.0:
                 if (heaterCurrent >= self.effectRate):
                     if (heaterCurrent <= heaterTarget-2):
-                        s = int(((heaterCurrent - self.effectRate) / heaterTarget) * 200)
+                        s = int(((heaterCurrent - self.effectRate) / (heaterTarget - self.effectRate)) * 200)
                         s = min(len(self.thisFrame)-1,s)
                         return self.thisFrame[s]
                     elif self.effectCutoff > 0:


### PR DESCRIPTION
When an effect rate was set, the heater effect did not use the full gradient but only a part of it.