### PR TITLE
Fix shutdown handler on recent Klipper where set_color is private

### DIFF
--- a/src/led_effect.py
+++ b/src/led_effect.py
@@ -128,7 +128,10 @@ class ledFrameHandler:
         for effect in self.effects:
             if not effect.runOnShutown:
                 for chain in self.ledChains:
-                    chain.led_helper.set_color(None, (0.0, 0.0, 0.0, 0.0))
+                    if hasattr(chain.led_helper, '_set_color'):
+                        chain.led_helper._set_color(None, (0.0, 0.0, 0.0, 0.0))
+                    else:
+                        chain.led_helper.set_color(None, (0.0, 0.0, 0.0, 0.0))
                     self._transmit_chain(chain)
                     
         pass


### PR DESCRIPTION
Recent Klipper made `LEDHelper.set_color` private (`_set_color`) — the same refactor that privatized `check_transmit`. `_handle_shutdown` still calls `set_color`, so `klippy:shutdown` raises `AttributeError` in the LED path. Falls back the same way `_transmit_chain` already handles `_check_transmit`/`check_transmit`.

Note: not exercised on a real `klippy:shutdown` (that's the only path it hits) — it's a direct mirror of the existing `_check_transmit`/`check_transmit` fallback a few lines above, and the module otherwise renders fine on current Klipper.
