### PR TITLE
Add dynamic ceiling and floor to TemperatureGauge (Cutoff=0 follows target, Rate<0 captures start temp)

### DIFF
--- a/docs/LED_Effect.md
+++ b/docs/LED_Effect.md
@@ -438,6 +438,17 @@ follows whatever the setpoint is, without hard-coding a temperature. A non-zero
 Cutoff keeps the original fixed-range behaviour. This requires a heater (a plain
 temperature sensor has no target).
 
+If the Effect Rate (Cold Temperature) is set to a value below `0`, the cold
+temperature is not fixed: it is captured from the current temperature at the
+moment the effect is enabled, and re-captured every time the effect is
+(re)enabled. Combined with a Cutoff of `0` (dynamic top), the gauge shows the
+progress of the current heat-up — empty at whatever temperature it started from,
+full at the live target — regardless of the starting point. An Effect Rate of 0
+or above keeps the original fixed-floor behaviour. To avoid noise when the effect
+is enabled with the heater already at its target (a near-zero span), a span at or
+below a small deadband is treated as "already there" (full). This requires a
+heater.
+
 #### Fire
     Effect Rate:  45  Probability of "sparking"
     Cutoff:       40  Rate of "cooling"

--- a/docs/LED_Effect.md
+++ b/docs/LED_Effect.md
@@ -438,6 +438,14 @@ follows whatever the setpoint is, without hard-coding a temperature. A non-zero
 Cutoff keeps the original fixed-range behaviour. This requires a heater (a plain
 temperature sensor has no target).
 
+If the Cutoff (Hot Temperature) is set to a value below `0`, the hot temperature
+is not fixed either: it is captured from the current temperature at the moment the
+effect is (re)enabled and used as the top — the mirror image of a negative Effect
+Rate. This is meant for cool-down: combined with a fixed cold-temperature floor,
+the gauge starts full at whatever temperature the cooling began and empties down
+to the floor as the heater cools, without hard-coding a temperature. A positive
+Cutoff keeps the original fixed-range behaviour. This requires a heater.
+
 If the Effect Rate (Cold Temperature) is set to a value below `0`, the cold
 temperature is not fixed: it is captured from the current temperature at the
 moment the effect is enabled, and re-captured every time the effect is

--- a/docs/LED_Effect.md
+++ b/docs/LED_Effect.md
@@ -430,6 +430,14 @@ temperature to the hot temperature its target is represented by the first color
 in the palette. The remaining colors form a gradient on the lower side of the 
 strip.
 
+If the Cutoff (Hot Temperature) is set to `0`, the hot temperature is taken from
+the heater's live target instead of a fixed value: the current target while
+heating, or the last non-zero target once the heater is switched off (e.g. during
+cool-down). This gives a fixed cold-temperature floor with a dynamic top that
+follows whatever the setpoint is, without hard-coding a temperature. A non-zero
+Cutoff keeps the original fixed-range behaviour. This requires a heater (a plain
+temperature sensor has no target).
+
 #### Fire
     Effect Rate:  45  Probability of "sparking"
     Cutoff:       40  Rate of "cooling"

--- a/src/led_effect.py
+++ b/src/led_effect.py
@@ -1140,17 +1140,28 @@ class ledEffect:
             self.frameCount = len(self.thisFrame)
 
         def nextFrame(self, eventtime):
-            if self.effectCutoff == self.effectRate:
-                s = len(self.thisFrame) if self.frameHandler.heaterCurrent[self.handler.heater] >= self.effectRate else 0
+            current = self.frameHandler.heaterCurrent[self.handler.heater]
+            floor   = self.effectRate
+            ceiling = self.effectCutoff
+
+            # A ceiling of 0 means "follow the heater's live setpoint": use the
+            # current target, or the last non-zero target once the heater is off
+            # (e.g. while cooling down). This gives a fixed floor with a dynamic
+            # top that tracks whatever the material's setpoint happens to be,
+            # without hard-coding any temperature. Backwards compatible: a
+            # non-zero ceiling behaves exactly as before.
+            if ceiling == 0:
+                target = self.frameHandler.heaterTarget[self.handler.heater]
+                last   = self.frameHandler.heaterLast[self.handler.heater]
+                ceiling = target if target > 0.0 else last
+
+            if ceiling <= floor:
+                s = len(self.thisFrame) if current >= floor else 0
             else:
-                s = int(((self.frameHandler.heaterCurrent[self.handler.heater] - 
-                            self.effectRate) / 
-                            (self.effectCutoff - self.effectRate)) * self.steps)
-                
+                s = int(((current - floor) / (ceiling - floor)) * self.steps)
+
             s = min(len(self.thisFrame)-1,s)
             s = max(0,s)
-
-
 
             return self.thisFrame[s]
 

--- a/src/led_effect.py
+++ b/src/led_effect.py
@@ -1147,12 +1147,15 @@ class ledEffect:
 
             self.frameCount = len(self.thisFrame)
             self.start_temp = None
+            self.start_ceiling = None
 
         def on_enabled(self):
             # Called when the parent effect is (re)enabled. Reset the captured
-            # start temperature so a dynamic floor (effectRate < 0) re-samples
-            # the current temperature for THIS heat-up.
+            # start temperatures so a dynamic floor (effectRate < 0) or a
+            # dynamic ceiling by capture (effectCutoff < 0) re-sample the
+            # current temperature for THIS heat-up / cool-down.
             self.start_temp = None
+            self.start_ceiling = None
 
         def nextFrame(self, eventtime):
             current = self.frameHandler.heaterCurrent[self.handler.heater]
@@ -1172,14 +1175,20 @@ class ledEffect:
 
             # A ceiling of 0 means "follow the heater's live setpoint": use the
             # current target, or the last non-zero target once the heater is off
-            # (e.g. while cooling down). This gives a FIXED floor with a DYNAMIC
-            # top that tracks whatever the material's setpoint happens to be,
-            # without hard-coding any temperature. Backwards compatible: a
-            # non-zero ceiling behaves exactly as before.
+            # (e.g. while cooling down). A ceiling below 0 means "capture the
+            # temperature when the effect is enabled and use it as the top" --
+            # the mirror of the dynamic floor, for cool-down: the bar starts
+            # full at whatever temperature the cooling began and empties down to
+            # the fixed floor. Backwards compatible: a ceiling > 0 is a fixed
+            # top, exactly as before.
             if ceiling == 0:
                 target = self.frameHandler.heaterTarget[self.handler.heater]
                 last   = self.frameHandler.heaterLast[self.handler.heater]
                 ceiling = target if target > 0.0 else last
+            elif ceiling < 0:
+                if self.start_ceiling is None:
+                    self.start_ceiling = current
+                ceiling = self.start_ceiling
 
             # Guard against a degenerate/near-zero span (e.g. the effect is
             # enabled when the heater is already at its target, so a captured

--- a/src/led_effect.py
+++ b/src/led_effect.py
@@ -539,6 +539,14 @@ class ledEffect:
     def set_enabled(self, state):
         if self.enabled != state:
             self.enabled = state
+            if state:
+                # Notify layers that the effect was (re)enabled. Lets a
+                # temperature gauge with a dynamic floor (effectRate < 0)
+                # re-sample the current temperature for THIS heat-up.
+                for layer in self.layers:
+                    on_enabled = getattr(layer, 'on_enabled', None)
+                    if on_enabled is not None:
+                        on_enabled()
             self.nextEventTime = self.handler.reactor.NOW
             self.handler._getFrames(self.handler.reactor.NOW)
     
@@ -1138,15 +1146,33 @@ class ledEffect:
                 self.thisFrame.append(frames2)
 
             self.frameCount = len(self.thisFrame)
+            self.start_temp = None
+
+        def on_enabled(self):
+            # Called when the parent effect is (re)enabled. Reset the captured
+            # start temperature so a dynamic floor (effectRate < 0) re-samples
+            # the current temperature for THIS heat-up.
+            self.start_temp = None
 
         def nextFrame(self, eventtime):
             current = self.frameHandler.heaterCurrent[self.handler.heater]
             floor   = self.effectRate
             ceiling = self.effectCutoff
 
+            # A floor below 0 means "capture the temperature when the effect is
+            # enabled and use it as the floor". The gauge then shows the PROGRESS
+            # of THIS heat-up: 0% at the start temperature, 100% at the top.
+            # Combined with a ceiling of 0 (dynamic top), the bar always fills
+            # 0->100% for the current heating, no matter where it started.
+            # Backwards compatible: a floor >= 0 behaves exactly as before.
+            if floor < 0:
+                if self.start_temp is None:
+                    self.start_temp = current
+                floor = self.start_temp
+
             # A ceiling of 0 means "follow the heater's live setpoint": use the
             # current target, or the last non-zero target once the heater is off
-            # (e.g. while cooling down). This gives a fixed floor with a dynamic
+            # (e.g. while cooling down). This gives a FIXED floor with a DYNAMIC
             # top that tracks whatever the material's setpoint happens to be,
             # without hard-coding any temperature. Backwards compatible: a
             # non-zero ceiling behaves exactly as before.
@@ -1155,8 +1181,17 @@ class ledEffect:
                 last   = self.frameHandler.heaterLast[self.handler.heater]
                 ceiling = target if target > 0.0 else last
 
-            if ceiling <= floor:
-                s = len(self.thisFrame) if current >= floor else 0
+            # Guard against a degenerate/near-zero span (e.g. the effect is
+            # enabled when the heater is already at its target, so a captured
+            # dynamic floor sits right under the ceiling). Dividing by a span of
+            # a few tenths of a degree turns sensor noise into a bar flickering
+            # across the whole strip. Treat a span at or below the deadband as
+            # "already there": full if the temperature reached the range, else
+            # empty. Backwards compatible: this also keeps an inverted fixed
+            # range fail-safe.
+            deadband = 2.0
+            if ceiling - floor <= deadband:
+                s = len(self.thisFrame) if current >= ceiling - deadband else 0
             else:
                 s = int(((current - floor) / (ceiling - floor)) * self.steps)
 
@@ -1165,7 +1200,7 @@ class ledEffect:
 
             return self.thisFrame[s]
 
-            
+
     #Responds to analog pin voltage
     class layerAnalogPin(_layerBase):
         def __init__(self,  **kwargs):


### PR DESCRIPTION
As discussed in #281.

TemperatureGauge gets two symmetric dynamic bounds, so a bar can track a real
heat-up or cool-down without hard-coding any temperature:

**Dynamic ceiling (Cutoff = 0):** the hot temperature follows the heater's live
target — the current target while heating, or the last non-zero target once the
heater is off (e.g. cool-down). A fixed floor with a top that tracks whatever the
setpoint is.

**Dynamic floor (Rate < 0):** the cold temperature is captured from the current
temperature at the moment the effect is enabled, and re-captured on each enable.
Combined with Cutoff = 0, the gauge becomes a pure progress bar of the current
heat-up: 0% at wherever it started, 100% at the live target, for any material.

Implementation: a no-op `on_enabled()` hook on layers, called from
`ledEffect.set_enabled()` when an effect is (re)enabled, lets the gauge re-sample
its start temperature. A small deadband guards the degenerate case where the
effect is enabled with the heater already at target — a near-zero span would
otherwise turn sensor noise into a bar flickering across the whole strip.

Backwards compatible: a non-zero Cutoff and a Rate >= 0 behave exactly as before.
Documentation updated in docs/LED_Effect.md.

Tested on a Voron 2.4 (v0.0.19-0) across real prints: cool-down bars empty at a
fixed floor; a post-probe heat-up starts at the probe temperature and fills to the
real setpoint; and a gauge enabled with the heater already at target stays solid
instead of flickering.